### PR TITLE
Add login.jsp to filter mappings to allow simple logouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ CAS integration for bonita community 7.7.4
     <filter-mapping>
         <filter-name>CAS Authentication Filter</filter-name>
         <url-pattern>/cas</url-pattern>
+        <url-pattern>/login.jsp</url-pattern>
     </filter-mapping>
 ```
 


### PR DESCRIPTION
Added "login.jsp" to filter mappings, so we can go to CAS page after logout.